### PR TITLE
Add query parameter to existence of lang file check

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -216,7 +216,7 @@ Polymer({
 		if (!formattedLang) {
 			return null;
 		}
-		var url = this.appRoot + '../d2l-html-editor/langs/' + formattedLang + '.js';
+		var url = this.appRoot + '../d2l-html-editor/langs/' + formattedLang + '.js?checkExists';
 		var http = new XMLHttpRequest();
 		http.open('HEAD', url, false);
 		http.send();


### PR DESCRIPTION
`No 'Access-Control-Allow-Origin' header` CORS error occurs when page is from the LMS, but the html-editor is from the CDN and a cached version of the request is used, which does not have the right CORS headers.
Try to prevent the browser from using the cached copy by including a query parameter in the URL.