### PR TITLE
add basic support for insert stuff

### DIFF
--- a/d2l-html-editor-client.js
+++ b/d2l-html-editor-client.js
@@ -1,11 +1,55 @@
 (function() {
 	'use strict';
+	/*global tinymce:true */
 
 	function request(type) {
 		switch (type) {
 			case 'valenceHost':
 				return Promise.resolve(window.location.origin);
 		}
+	}
+
+	function insertStuff() {
+		return Promise.resolve({
+			config: function() {
+				return Promise.resolve({
+					isEnabled: true
+				});
+			},
+			click: function(openerId) {
+				return new Promise(function(resolve, reject) {
+					var nav = new D2L.Nav();
+					var location = new D2L.LP.Web.Http.UrlLocation('/d2l/common/dialogs/isf/selectItem.d2l')
+						.WithQueryString('ou', nav.GetParam('ou'))
+						.WithQueryString('filterMode', 'Strict');
+					var openEvent = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
+						new D2L.LP.Web.UI.Html.AbsoluteHtmlId.Create(openerId),
+						location,
+						'GetSelectedItem',
+						'', /* resizeCallback*/
+						'itemSource',
+						975,
+						650,
+						tinymce.EditorManager.i18n.translate('Close'),
+						[{
+							IsEnabled: true,
+							IsPrimary: true,
+							Key: 'BTN_next',
+							Param: 'next',
+							ResponseType: 1,
+							Text: tinymce.EditorManager.i18n.translate('Next')
+						}], /* buttons */
+						false /* forceTriggerOnCancel */
+					);
+					openEvent.AddListener(function(result) {
+						resolve(result);
+					});
+					openEvent.AddReleaseListener(function() {
+						reject();
+					});
+				});
+			}
+		});
 	}
 
 	function convertToViewableHtml() {
@@ -41,6 +85,8 @@
 		switch (serviceType) {
 			case 'convert-to-viewable-html':
 				return convertToViewableHtml();
+			case 'fra-html-editor-isf':
+				return insertStuff();
 			default:
 				return Promise.resolve({
 					config: function() {

--- a/d2l-insertstuff-plugin.html
+++ b/d2l-insertstuff-plugin.html
@@ -346,7 +346,7 @@ Check that file periodically for changes...
 
 		function command(service, editor) {
 			var bookmark = editor.selection.getBookmark();
-			service.click().then(function(response) {
+			service.click(editor.id).then(function(response) {
 				setTimeout(function() {
 					document.activeElement.blur();
 					editor.focus();

--- a/d2l_lang_plugin/langs/en_CA.js
+++ b/d2l_lang_plugin/langs/en_CA.js
@@ -73,6 +73,8 @@ tinymce.addI18n('en_CA',{
 "Use list markup for lists.": "Use list markup for lists.",
 "Large text must have a contrast ratio of at least 3:1.": "Large text must have a contrast ratio of at least 3:1.",
 "Visual presentation must have a contrast ratio of at least 4.5:1.": "Visual presentation must have a contrast ratio of at least 4.5:1.",
+"Next": "Next",
+"Close": "Close",
 
 // d2l-emoticons plugin
 "blue funster": "blue funster",


### PR DESCRIPTION
Adds support for the insert stuff dialog when using web component from LMS.

Currently this does not have any mechanism to respect the LMS setting to disable 'Insert Stuff' and it also includes a hack to get the current org unit from the current browser location.

I'm going to work on providing an updated hypermedia API that will allow that data to be encapsulated in a siren entity which can be used to configure the HTML editor rather than hardcoding these configs.