### PR TITLE
Ensure each instance of the html-editor has a valid langTag

### DIFF
--- a/d2l-html-editor-bundled.js
+++ b/d2l-html-editor-bundled.js
@@ -1659,14 +1659,23 @@ Polymer({
 		this.cleanup();
 	},
 
-	_changeLangTag: function() {
-		var langTag = this._checkIfLangExists(this.langTag)
-			|| this._checkIfLangExists(window.document.getElementsByTagName('html')[0].getAttribute('lang'))
-			|| this._checkIfLangExists(window.document.getElementsByTagName('html')[0].getAttribute('data-lang-default'))
-			|| this._checkIfLangExists('en_US');
+	_findValidLangTag: function() {
+		var langTag = this.langTag;
+		var formattedLangTag = this._formatLangTag(langTag);
+		var htmlLangAttr = this._formatLangTag(window.document.getElementsByTagName('html')[0].getAttribute('lang'));
+		var htmlDefaultLangAttr = this._formatLangTag(window.document.getElementsByTagName('html')[0].getAttribute('data-lang-default'));
 
-		this.langAvailable.bool = !!langTag;
-		this.langTag = langTag;
+		if (this._checkIfLangExists(langTag)) {
+			this.langTag = langTag;
+		} else if (this._checkIfLangExists(formattedLangTag)) {
+			this.langTag = formattedLangTag;
+		} else if (this._checkIfLangExists(htmlLangAttr)) {
+			this.langTag = htmlLangAttr;
+		} else if (this._checkIfLangExists(htmlDefaultLangAttr)) {
+			this.langTag = htmlDefaultLangAttr;
+		} else {
+			this.langTag = 'en_US';
+		}
 	},
 
 	//converts the d2l lang tag into a format that fits with tinyMCE lang files
@@ -1681,19 +1690,24 @@ Polymer({
 	},
 
 	_checkIfLangExists: function(langTag) {
-		var formattedLang = this._formatLangTag(langTag);
-		if (!formattedLang) {
-			return null;
+		if (langTag) {
+			if (langTag in this.langAvailable) {
+				return this.langAvailable[langTag];
+			} else {
+				var langExists = this._checkIfLangFileExists(langTag);
+				this.langAvailable[langTag] = langExists;
+				return langExists;
+			}
 		}
-		var url = this.appRoot + '../d2l-html-editor/langs/' + formattedLang + '.js?checkExists';
+		return false;
+	},
+
+	_checkIfLangFileExists: function(langTag) {
+		var url = this.appRoot + '../d2l-html-editor/langs/' + langTag + '.js?checkExists';
 		var http = new XMLHttpRequest();
 		http.open('HEAD', url, false);
 		http.send();
-		if (Math.floor(http.status / 100) !== 4 && Math.floor(http.status / 100) !== 5) {
-			return formattedLang;
-		} else {
-			return null;
-		}
+		return Math.floor(http.status / 100) !== 4 && Math.floor(http.status / 100) !== 5;
 	},
 
 	_configurePlugins: function(client) {
@@ -1872,9 +1886,8 @@ Polymer({
 	_initTinyMCE: function(valenceHost) {
 		var that = this;
 
-		if (this.langAvailable.bool === undefined || this.langAvailable.bool === null) {
-			this._changeLangTag();
-		}
+		this._findValidLangTag();
+
 		var contentCss = '';
 		if (!this.inline) {
 			contentCss += this.cssUrl + ',';
@@ -1938,7 +1951,7 @@ Polymer({
 			d2l_html_editor: that,
 			selector: '#' + this.editorId,
 
-			external_plugins: this.langTag && this.langTag !== 'en_US' && this.langAvailable.bool ? {'d2l_lang': this.appRoot + '../d2l-html-editor/d2l_lang_plugin/d2l-lang-plugin.js'} : null,
+			external_plugins: this.langTag && this.langTag !== 'en_US' && this.langAvailable[this.langTag] ? {'d2l_lang': this.appRoot + '../d2l-html-editor/d2l_lang_plugin/d2l-lang-plugin.js'} : null,
 			plugins: this.plugins,
 			toolbar: this.toolbar,
 			fontsize_formats: '8pt 10pt 12pt 14pt 18pt 24pt 36pt',
@@ -1967,8 +1980,8 @@ Polymer({
 			skin_url: this.appRoot + '../d2l-html-editor/skin-4.3.7',
 			convert_urls: false,
 			relative_urls: false,
-			language_url: this.langTag && this.langAvailable.bool ? this.appRoot + '../d2l-html-editor/langs/' + this.langTag + '.js' : null,
-			language: this.langTag && this.langAvailable.bool ? this.langTag : null,
+			language_url: this.langTag && this.langAvailable[this.langTag] ? this.appRoot + '../d2l-html-editor/langs/' + this.langTag + '.js' : null,
+			language: this.langTag && this.langAvailable[this.langTag] ? this.langTag : null,
 			directionality: this.langDir,
 			object_resizing: this.objectResizing,
 			powerpaste_word_import: this.powerPasteFormatting,

--- a/d2l-html-editor-bundled.js
+++ b/d2l-html-editor-bundled.js
@@ -1660,14 +1660,11 @@ Polymer({
 	},
 
 	_findValidLangTag: function() {
-		var langTag = this.langTag;
-		var formattedLangTag = this._formatLangTag(langTag);
+		var formattedLangTag = this._formatLangTag(this.langTag);
 		var htmlLangAttr = this._formatLangTag(window.document.getElementsByTagName('html')[0].getAttribute('lang'));
 		var htmlDefaultLangAttr = this._formatLangTag(window.document.getElementsByTagName('html')[0].getAttribute('data-lang-default'));
 
-		if (this._checkIfLangExists(langTag)) {
-			this.langTag = langTag;
-		} else if (this._checkIfLangExists(formattedLangTag)) {
+		if (this._checkIfLangExists(formattedLangTag)) {
 			this.langTag = formattedLangTag;
 		} else if (this._checkIfLangExists(htmlLangAttr)) {
 			this.langTag = htmlLangAttr;

--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -191,14 +191,11 @@ Polymer({
 	},
 
 	_findValidLangTag: function() {
-		var langTag = this.langTag;
-		var formattedLangTag = this._formatLangTag(langTag);
+		var formattedLangTag = this._formatLangTag(this.langTag);
 		var htmlLangAttr = this._formatLangTag(window.document.getElementsByTagName('html')[0].getAttribute('lang'));
 		var htmlDefaultLangAttr = this._formatLangTag(window.document.getElementsByTagName('html')[0].getAttribute('data-lang-default'));
 
-		if (this._checkIfLangExists(langTag)) {
-			this.langTag = langTag;
-		} else if (this._checkIfLangExists(formattedLangTag)) {
+		if (this._checkIfLangExists(formattedLangTag)) {
 			this.langTag = formattedLangTag;
 		} else if (this._checkIfLangExists(htmlLangAttr)) {
 			this.langTag = htmlLangAttr;


### PR DESCRIPTION
**Defect Description**
E.g. we have two instances that need to be initialized. they both pass in `''` or `null` for the `langTag` property.
The first instance computes a valid `langTag` and sets it to the `langTag` property. `langAvailable.bool` is set to true at this time.
The second instance re-uses the `langAvailable` object and sees that the `bool` property is true. Thus, it skips computing a valid langTag. When `d2l_lang_plugin` loads, `langTag` is still null, thus it loads the default `en`.


**Steps to Fix**
- continue to use the `langAvailable` object, but this time, store the langTags in the object with a true/false value depending on whether the lang file exists, rather than the `bool` property.
- other new instances will always check to ensure they have a valid `langTag`. They will use the `langAvailable` object to prevent redundant checks for existence of lang files.