### PR TITLE
remove initialization code that cleared 'content' property as this br…

### DIFF
--- a/d2l-filter-plugin.html
+++ b/d2l-filter-plugin.html
@@ -31,15 +31,6 @@
 									//When you first enter an editor, and change the table properties (it won't create a change event
 									//until there is already an undo action in the undomanager)
 									editor.undoManager.add();
-
-									// After initial initialization, clear content. The web component may become
-									// detached due to React reordering.	This will cause a re-init, but we want
-									// it to re-init from the current content.	We will look at preventing
-									// initialization on attach/detach in future.	However, detach is currently
-									// the simplest place to clean up the TinyMCE editor.	Probably should include
-									// a property to auto clean up, otherwise would need to explicitly call a clean
-									// up method from React componentWillUnmount.
-									editor.getParam('d2l_html_editor').content = null;
 								}).catch(function() {
 									console.warn('d2l_filter_plugin not enabled'); // eslint-disable-line
 								});


### PR DESCRIPTION
…eaks re-rendering on key change if content hasn't actually changed.  This is because components that are using the d2l-html-editor won't update their properties, so computed properties/functions that are intended to set the d2l-html-editor property to the correct new (but unchanged) value won't fire and so the content property on the d2l-html-editor never gets put back to a valid value.

I don't believe clearing the d2l-html-editor content property on initialization is required anymore anyway. I think this was originally put in as a hack based on how we were originally initializing the content property of the tinymce editor. An editor that was detached/attached would re-initalize the tinymce content with the original value of the content property somehow and lose any subsequent changes, but I'm pretty sure that no longer happens.