### PR TITLE
replace literal in dynamic import with variable to try and workaround…

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -13,6 +13,7 @@ window.tinyMCEPreInit = {
 	baseURL: tinymceBaseUrl,
 	suffix: ''
 };
+const editorComponent = './d2l-html-editor-component.js';
 import(tinymceBaseUrl + '/tinymce.js').then(function() {
-	import('./d2l-html-editor-component.js');
+	import(editorComponent);
 });


### PR DESCRIPTION
… polymer build issues in components that use this component.

The dynamic import
`import('./d2l-html-editor-component.js');`

seemed to break the polymer build in application components that tried to use d2l-html-editor. The analyzer kept complaining that it couldn't find `./d2l-html-editor-component.js` even though the path that it was reporting as invalid looked correct. 

Changing from a literal to a variable seems to correct this - maybe because the analyzer ignores dynamic expressions in dynamic imports. 

Not sure if this will break the actual usage of the component. This repo's demo still seems to work correctly in Chrome when I switch the demo to use the dynamic import file `d2l-html-editor.js`.