### PR TITLE
referencing d2l-fetch-auth using semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
-    "d2l-fetch-auth": "github:Brightspace/d2l-fetch-auth",
+    "d2l-fetch-auth": "^1.2.0",
     "d2l-icons": "BrightspaceUI/icons#semver:^6"
   }
 }


### PR DESCRIPTION
Without this change, when this gets pulled into rubrics, and then into BSI, NPM can't decide between the version this is asking for (latest on master) and what BSI is asking for (`^1.2.0`), so we end up with two copies. We have a build step in BSI to check that multiple copies of a dependency aren't being included in our bundles, which is how we caught this.