### PR TITLE
Fix insert-stuff with shadow dom

### DIFF
--- a/d2l-html-editor-client.js
+++ b/d2l-html-editor-client.js
@@ -18,11 +18,11 @@
 					isEnabled: pluginSettings.hasOwnProperty('d2l_isf')
 				});
 			},
-			click: function(openerId) {
+			click: function(opener) {
 				return new Promise(function(resolve, reject) {
 					var location = new D2L.LP.Web.Http.UrlLocation(pluginSettings.d2l_isf.endpoint);
 					var openEvent = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
-						new D2L.LP.Web.UI.Html.AbsoluteHtmlId.Create(openerId),
+						opener,
 						location,
 						'GetSelectedItem',
 						'', /* resizeCallback*/

--- a/d2l-insertstuff-plugin.js
+++ b/d2l-insertstuff-plugin.js
@@ -369,7 +369,7 @@ function convertToElements(context) {
 
 function command(service, editor) {
 	var bookmark = editor.selection.getBookmark();
-	service.click(editor.id).then(function(response) {
+	service.click(editor).then(function(response) {
 		setTimeout(function() {
 			document.activeElement.blur();
 			editor.focus();


### PR DESCRIPTION
Pass element reference to `opener` in LMS dialog instead of id.
Will only merge after the LMS change is in https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/12225/overview.