### PR TITLE
Stop editor toolbar displaying over insert-stuff loading screen

### DIFF
--- a/d2l-insertstuff-plugin.js
+++ b/d2l-insertstuff-plugin.js
@@ -369,9 +369,10 @@ function convertToElements(context) {
 
 function command(service, editor) {
 	var bookmark = editor.selection.getBookmark();
-	document.activeElement.blur();
+	editor.targetElm.blur();
 	service.click(editor.id).then(function(response) {
 		setTimeout(function() {
+			document.activeElement.blur();
 			editor.focus();
 			editor.selection.moveToBookmark(bookmark);
 			editor.execCommand('mceInsertContent', false, response);

--- a/d2l-insertstuff-plugin.js
+++ b/d2l-insertstuff-plugin.js
@@ -369,9 +369,9 @@ function convertToElements(context) {
 
 function command(service, editor) {
 	var bookmark = editor.selection.getBookmark();
+	document.activeElement.blur();
 	service.click(editor.id).then(function(response) {
 		setTimeout(function() {
-			document.activeElement.blur();
 			editor.focus();
 			editor.selection.moveToBookmark(bookmark);
 			editor.execCommand('mceInsertContent', false, response);


### PR DESCRIPTION
Addresses: https://trello.com/c/U6AGBaKO/98-rubrics-html-editor-toolbar-renders-on-top-of-insert-stuff-loading-screen

The toolbar was only displaying because it only loses focus once the dialog has loaded. By `blur`ring it as soon as the insert-stuff button is clicked, it is no longer visible over the loading screen.