### PR TITLE
filter ShadyCSS style-scope and scope classes from editor content

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -955,9 +955,8 @@ Polymer({
 		while (target.parentNode) {
 			target = target.parentNode;
 		}
-		// If there is no parent node, but there is `host` property - we've just found Shadow Root,
-		// where we'll get selection. Note for Chrome the shadowRoot implements the DocumentOrShadowRoot mixin
-		// but in other browsers it is still implemented on the document
+		// If there is no parent node, but there is `host` property - we've just found Shadow Root
+		// host is the element which includes the html editor component.
 		return target.host;
 	},
 

--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -289,7 +289,7 @@ Polymer({
 		// import for tinymce. However using a dynamic import for tinymce also has the additional advantage
 		// that we only load tinymce if a component on the page uses it. Otherwise if this component ends up
 		// in shared polymer bundles, we would be loading tinymce even if the component wasn't used.
-		const tinymceBaseUrl = 'https://s.brightspace.com/lib/tinymce/dev/4.8.5-a11ychecker.1.2.1-53-powerpaste.3.3.3-308-shadow-dom-fork-3';
+		const tinymceBaseUrl = 'https://s.brightspace.com/lib/tinymce/dev/4.8.5-a11ychecker.1.2.1-53-powerpaste.3.3.3-308-shadow-dom-fork-6';
 		window.tinyMCEPreInit = {
 			baseURL: tinymceBaseUrl,
 			suffix: ''
@@ -937,10 +937,28 @@ Polymer({
 			}
 		}
 
+		if (window.ShadyDOM && window.ShadyDOM.inUse) {
+			const shadowHost = this.getShadowHost(this);
+			if (shadowHost) {
+				const scope = shadowHost.nodeName.toLowerCase();
+				config.invalid_classes = 'style-scope ' + scope;
+			}
+		}
+
 		tinymce.init(this._extend(this.pluginConfig, config));
 
 		// need to reset auto focus property to prevent unwanted focus during re-ordering of the options
 		this.autoFocus = 0;
+	},
+
+	getShadowHost: function(target) {
+		while (target.parentNode) {
+			target = target.parentNode;
+		}
+		// If there is no parent node, but there is `host` property - we've just found Shadow Root,
+		// where we'll get selection. Note for Chrome the shadowRoot implements the DocumentOrShadowRoot mixin
+		// but in other browsers it is still implemented on the document
+		return target.host;
 	},
 
 	computeToolbarId: function(editorId) {

--- a/demo/d2l-editor-wrapper.js
+++ b/demo/d2l-editor-wrapper.js
@@ -27,14 +27,16 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-editor-wrapper">
 
 		</style>
 		<h2>Hello [[prop1]]!</h2>
-		<d2l-html-editor
-			editor-id="[[prop1]]"
-			toolbar="[[_toolbar]]"
-			plugins="[[_plugins]]"
-			app-root="[[_appRoot]]"
-		>
-			<div id="[[prop1]]" class="d2l-richtext-editor-container"></div>
-		</d2l-html-editor>
+		<div>
+			<d2l-html-editor
+				editor-id="[[prop1]]"
+				toolbar="[[_toolbar]]"
+				plugins="[[_plugins]]"
+				app-root="[[_appRoot]]"
+			>
+				<div id="[[prop1]]" class="d2l-richtext-editor-container"></div>
+			</d2l-html-editor>
+		</div>
 	</template>
 
 </dom-module>`;


### PR DESCRIPTION
Added a new feature to our tinymce fork for filtering invalid classes, which surprisingly tinymce doesn't currently support, even though it supports valid_classes and invalid_styles.

This change checks to see if ShadyDOM is in use, and if so determines the current shadow host which will be defining the shady CSS style scope, and adds that scope and the `style-scope` class to the list of invalid classes. tinymce will filter these classes from the html editor content when the html editor content is retrieved, e.g. in change events etc.