### PR TITLE
explicitly hide toolbars when dialog shows.

### DIFF
--- a/d2l-insertstuff-plugin.js
+++ b/d2l-insertstuff-plugin.js
@@ -377,7 +377,7 @@ function command(service, editor) {
 		toolbar.style.display = 'none';
 	});
 
-	service.click(editor).then(function (response) {
+	service.click(editor).then(function(response) {
 		setTimeout(function() {
 			document.activeElement.blur();
 			editor.focus();

--- a/d2l-insertstuff-plugin.js
+++ b/d2l-insertstuff-plugin.js
@@ -370,7 +370,14 @@ function convertToElements(context) {
 function command(service, editor) {
 	var bookmark = editor.selection.getBookmark();
 	editor.targetElm.blur();
-	service.click(editor).then(function(response) {
+
+	/* force toolbar to hide in Edge */
+	var toolbars = editor.getDoc().querySelectorAll('.mce-floatpanel');
+	toolbars.forEach(function(toolbar) {
+		toolbar.style.display = 'none';
+	});
+
+	service.click(editor).then(function (response) {
 		setTimeout(function() {
 			document.activeElement.blur();
 			editor.focus();


### PR DESCRIPTION
Fixes https://trello.com/c/U6AGBaKO/98-edge-html-editor-toolbar-renders-on-top-of-insert-stuff-loading-screen