### PR TITLE
Clear content not performing as expected

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -529,6 +529,9 @@ Polymer({
 
 	clearContent: function() {
 		tinymce.EditorManager.get(this.editorId).setContent('');
+		tinymce.EditorManager.get(this.editorId).undoManager.clear();
+		tinymce.EditorManager.get(this.editorId).undoManager.add();
+		this.fire('change', {content: tinymce.EditorManager.get(this.editorId).getContent()});
 	},
 
 	_keyChanged: function(newKey, oldKey) {


### PR DESCRIPTION
Fixes...
Issue 1: If we explicitly 'clearContent', we should clear the undo stack as well.
Issue 2: When we explicitly setContent, an undo level is not added. This means that before and after clearing, if the content is the same (i.e. paste the same content back in), the editor will think the content stayed the same, and will not fire a change event.
Issue 3: Explicitly setting the content does not fire a 'change' event. We should fire a change event so that consumers of the editor will be notified that the new value is ''.