### PR TITLE
Handle multiple html-editor inline toolbars on a page.

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -872,9 +872,11 @@ Polymer({
 
 				editor.on('keydown', function(e) {
 					if (e.key === 'Escape' || e.key === 'Esc') { // 'Esc' is to support IE
-						const inlineToolbar = document.getElementsByClassName('mce-tinymce-inline')[0];
-						if (inlineToolbar) {
-							inlineToolbar.style.display = 'none';
+						const inlineToolbars = document.getElementsByClassName('mce-tinymce-inline');
+						if (inlineToolbars.length) {
+							Array.prototype.forEach.call(inlineToolbars, function(inlineToolbar) {
+								inlineToolbar.style.display = 'none';
+							});
 							// Hide any floating panels/menus opened from toolbar
 							const floatingPanels = document.getElementsByClassName('mce-floatpanel');
 							Array.prototype.forEach.call(floatingPanels, function(floatingPanel) {


### PR DESCRIPTION
Every inline toolbar that appears stays in the DOM (although it may be hidden). The behavior is the same in AF, Quizzing, and Rubrics. I couldn't find anything that uniquely links a toolbar to an editor, so I have to loop through all the inline toolbar elements and hide all of them even though only one would be showing at any one time.