### PR TITLE
Re-checking if the editor should be disabled once the editor is loaded

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -749,6 +749,9 @@ Polymer({
 			},
 			setup: function(editor) {
 				that.editor = editor;
+
+				that._disabledChanged(that.disabled);
+				
 				function translateAccessibility(node) {
 					if (node.nodeType === 1) {
 

--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -751,7 +751,7 @@ Polymer({
 				that.editor = editor;
 
 				that._disabledChanged(that.disabled);
-				
+
 				function translateAccessibility(node) {
 					if (node.nodeType === 1) {
 


### PR DESCRIPTION
Currently if the disabled property is set on the d2l-html-editor, it attempts to apply that before the internal editor is loaded. 

So I have added a call to the disable function after we have the editor.