### PR TITLE
Add attribute to block local image pasting

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -200,6 +200,10 @@ Polymer({
 			type: Number,
 			value: 0
 		},
+		powerPasteAllowLocaleImages: {
+			type: Number,
+			value: 1
+		},
 		powerPasteFormatting: {
 			type: String,
 			value: null
@@ -703,7 +707,7 @@ Polymer({
 			directionality: this.langDir,
 			object_resizing: this.objectResizing,
 			powerpaste_word_import: this.powerPasteFormatting,
-			powerpaste_allow_local_images: this.powerPasteEnabled ? true : false,
+			powerpaste_allow_local_images: this.powerPasteEnabled && this.powerPasteAllowLocaleImages ? true : false,
 			powerpaste_block_drop : false,
 			paste_as_text: this.powerPasteEnabled ? false : true,
 			paste_text_sticky: this.powerPasteEnabled ? false : true,

--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -200,7 +200,7 @@ Polymer({
 			type: Number,
 			value: 0
 		},
-		powerPasteAllowLocaleImages: {
+		powerPasteAllowLocalImages: {
 			type: Number,
 			value: 1
 		},
@@ -707,7 +707,7 @@ Polymer({
 			directionality: this.langDir,
 			object_resizing: this.objectResizing,
 			powerpaste_word_import: this.powerPasteFormatting,
-			powerpaste_allow_local_images: this.powerPasteEnabled && this.powerPasteAllowLocaleImages ? true : false,
+			powerpaste_allow_local_images: this.powerPasteEnabled && this.powerPasteAllowLocalImages ? true : false,
 			powerpaste_block_drop : false,
 			paste_as_text: this.powerPasteEnabled ? false : true,
 			paste_text_sticky: this.powerPasteEnabled ? false : true,


### PR DESCRIPTION
Introduce a new field so that the html editor can be used with power paste functionality - but one feature of power paste (local image pasting) can be disabled.

Here's a screenshot of an example I used where I was able to copy + paste the text with formatting, but it didn't let me paste in a local image:

![paste1](https://user-images.githubusercontent.com/14796305/71926160-49026c00-3158-11ea-9112-82713ea8f718.PNG)
