### PR TITLE
DE37309 Updating the editor content when the content property gets ch…

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -162,7 +162,8 @@ Polymer({
 			computed: 'computeToolbarId(editorId)'
 		},
 		content: {
-			type: String
+			type: String,
+			observer: '_contentChanged'
 		},
 		baseUrl: {
 			type: String,
@@ -255,6 +256,13 @@ Polymer({
 	 * @return {HTMLElement}
 	 */
 	element: null,
+
+	_contentChanged: function(content) {
+		if (this.editor) {
+			var decodedContent = decodeURIComponent(this.content);
+			this.editor.setContent(decodedContent);
+		}
+	},
 
 	_disabledChanged: function(disabled) {
 		if (disabled) {

--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -259,7 +259,7 @@ Polymer({
 
 	_contentChanged: function(content) {
 		if (this.editor) {
-			var decodedContent = decodeURIComponent(this.content);
+			var decodedContent = decodeURIComponent(content);
 			this.editor.setContent(decodedContent);
 		}
 	},


### PR DESCRIPTION
…anged.

This is to fix a [defect](https://rally1.rallydev.com/#/detail/defect/359820964944) in our component. We are unable to guarantee that we have the content when the html editor is rendered, so we need to be able to update the content attribute on the editor when we have it.