### PR TITLE
Make cleanup safe in the case where it is called before attached has finished

### DIFF
--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -513,14 +513,19 @@ Polymer({
 	// We cannot cleanup in detached because React seems to cause the web component
 	// to detach/attach during move operations
 	cleanup: function() {
-		var editor = tinymce.EditorManager.get(this.editorId);
-		if (editor) {
-		// prevent save before remove, since it throws an exception when the HTML content contains a table
-			editor.save = function() {};
-			editor.remove();
+		if (window.tinymce) {
+			var editor = tinymce.EditorManager.get(this.editorId);
+			if (editor) {
+			// prevent save before remove, since it throws an exception when the HTML content contains a table
+				editor.save = function() {};
+				editor.remove();
+			}
 		}
+
 		this.client = null;
-		this.element.removeEventListener('focusin', this._focusInHandler);
+		if (this.element) {
+			this.element.removeEventListener('focusin', this._focusInHandler);
+		}
 	},
 
 	focus: function() {

--- a/d2l-html-editor.js
+++ b/d2l-html-editor.js
@@ -987,7 +987,10 @@ Polymer({
 			config.height = 1;
 		}
 
-		tinymce.init(this._extend(this.pluginConfig, config));
+		// This is to avoid a memory leak if the cleanup code in detached runs before this code
+		if (this.isAttached) {
+			tinymce.init(this._extend(this.pluginConfig, config));
+		}
 
 		// need to reset auto focus property to prevent unwanted focus during re-ordering of the options
 		this.autoFocus = 0;


### PR DESCRIPTION
Problem: If you add and remove `d2l-html-editor` quickly (say in a basic unit test) it fails because `tinymce` is `undefined`. This is because the way `detached` is written assumes that `attached` has completed.

`attached` contains code to dynamically import `tinymce`, configure it, and add it to the DOM which takes a relatively long time. `detached` is quite fast, just resetting some variables and removing event listeners.

This PR includes code to make `cleanup` (`detached` calls `cleanup`) not throw. I'm not sure if this is the correct approach but it does solve my problem.