### PR TITLE
fix: add defensive checks into replacestring plugin

### DIFF
--- a/d2l-replacestring-plugin.js
+++ b/d2l-replacestring-plugin.js
@@ -26,11 +26,15 @@ function encodeReplaceStrings(context, replacementToken, replacementValue) {
 			// when we replace later.
 			tempNode.innerHTML = match;
 			var img = tempNode.firstChild;
+			if (!img) return match;
+
 			var src = img.getAttribute('data-mce-src'); //plugin.Attributes.Data);
 
 			if (!src) {
 				src = img.getAttribute('src');
 			}
+			if (!src) return match;
+
 			var originalSrc = src;
 
 			// loop through possible replace strings and replace them
@@ -72,6 +76,8 @@ function decodeReplaceStrings(obj) {
 			tempNode.innerHTML = match;
 
 			var img = tempNode.firstChild;
+			if (!img) return match;
+
 			var d2l_src = img.getAttribute('data-d2l-src');
 
 			if (d2l_src !== '') {


### PR DESCRIPTION
## Relevant Rally Links 
​
[DE43613](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F605299693800&fdp=true?fdp=true): elo > ugdsb > 20.21.4 > content > content activity cannot be edited

## Description
​
Currently when attempting to edit content with `img` tags that contain `>` characters in the `alt` text attribute the editor crashes.
​
## Goal/Solution
​
The crash occurs due to a malformed regex match and a lack of defensive checking against such a thing. The regex sees the `>` character and believes it to be the end of the tag. This causes the subsequent attempt to convert the tag string into a DOM element to fail, which ultimately throws an error when the element is attempted to be accessed for one of it's attributes.

While a grander solution may be to replace the regex entirely or modify it to account for the `>` character, it is worth noting that the `>` itself is not valid HTML. As such, for now we feel it is reasonable to simply guard against a full failure to render and simply ignore malformed regex matches via defensive coding.

A sample `img` tag that will cause this failure:

```html
<img src="_images/definition.jpg" alt="1a:  a charred piece of wood   b:  firebrand 1  c:  something (as lightning) that resembles a firebrand
2:  sword
3a(1):  a mark made by burning with a hot iron to attest manufacture or quality or to designate ownership (2):  a printed mark made for similar purposes:  trademark b(1):  a mark put on criminals with a hot iron (2):  a mark of disgrace:  stigma <the brand of poverty>
4a:  a class of goods identified by name as the product of a single firm or manufacturer:  make b:  a characteristic or distinctive kind <a lively brand of theater> c:  brand name 2 5: a tool used to produce a brand" class="img-rounded img-responsive center-block" />
```

## Video/Screenshots
​
before:
![before-d2l-html-editor-fix](https://user-images.githubusercontent.com/2243995/118861732-727dec80-b8a2-11eb-8b07-399f89f55034.gif)

after:
![after-d2l-html-editor-fix](https://user-images.githubusercontent.com/2243995/118861753-79a4fa80-b8a2-11eb-93a6-57fd0d25c6d8.gif)

​
## Remaining Work

n/a
​​
