### PR TITLE
fix: remove unneeded imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: 14
 addons:
   chrome: stable
 script:

--- a/d2l-placeholder-styles.js
+++ b/d2l-placeholder-styles.js
@@ -1,11 +1,10 @@
-import 'd2l-colors/d2l-colors.js';
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-placeholder-styles">
   <template>
 	<style>
 		:host ::slotted(.html-editor-container-hover) {
-			border-color: var(--d2l-color-celestine);
+			border-color: #006fbf; /*$d2l-color-celestine*/
 			border-width: 2px;
 			outline-width: 0;
 			padding: calc(0.4rem - 1px) calc(1rem - 1px)
@@ -15,7 +14,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-placeholder-styles"
 			position: absolute;
 			top: 0;
 			left: 0;
-			color:var(--d2l-color-pressicus);
+			color: #b9c2d0; /*d2l-colors-pressicus*/
 			font-size: 0.8rem;
 			line-height: 1.2rem;
 			padding: 0.4rem 1rem;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "homepage": "https://github.com/Brightspace/d2l-html-editor#readme",
   "name": "d2l-html-editor",
   "version": "2.0.19",
-  "main": "index.js",
   "directories": {
     "test": "test"
   },
@@ -43,17 +42,9 @@
     "polymer-cli": "^1.9.4",
     "wct-browser-legacy": "^1.0.1"
   },
-  "resolutions": {
-    "inherits": "2.0.3",
-    "samsam": "1.1.3",
-    "supports-color": "3.1.2",
-    "type-detect": "1.0.0"
-  },
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
-    "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
-    "d2l-fetch-auth": "^1.2.0",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
-    "d2l-colors": "BrightspaceUI/colors#semver:^4"
+    "@polymer/polymer": "^3",
+    "d2l-fetch": "github:Brightspace/d2l-fetch.git#semver:^2",
+    "d2l-fetch-auth": "^1"
   }
 }


### PR DESCRIPTION
The `d2l-icons` package wasn't used anywhere (looks to have been replaced by https://github.com/Brightspace/d2l-html-editor/blob/master/d2l-icons.css) and there were 2 colors that were used from `d2l-colors` but they had already been hard-coded elsewhere so followed suite to eliminate need for it.