### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-html-editor#readme",
   "name": "d2l-html-editor",
-  "version": "2.0.19",
+  "version": "2.0.21",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
No auto release on this repo 😞. Will have to do release manually. Double bumping since there is already a `2.0.20` release.